### PR TITLE
Add a UI camera to the example code in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(bevy_screen_diags::ScreenDiagsPlugin)
+        //If a UI camera is already in your game remove the next line
+        .add_startup_system(|mut commands: Commands| {commands.spawn_bundle(UiCameraBundle::default());})
         :
         :
 }


### PR DESCRIPTION
For beginners with bevy like me, it takes some time to realize that the reason that the FPS is not showing is that no UI camera is present in the project.  This line added to the readme should avoid most confusion.