### PR TITLE
Remove unnecessary unsafe usage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,6 @@
 //! Add a diagnostics overlay (with an FPS counter) in Bevy.
 //!
 //! This crate provides a Bevy [plugin](ScreenDiagsPlugin) to add the diagnostics overlay.
-
-use std::fmt::Write;
-
 use bevy::{
     diagnostic::{Diagnostics, FrameTimeDiagnosticsPlugin},
     prelude::*,
@@ -82,12 +79,8 @@ fn extract_fps(diagnostics: Res<Diagnostics>) -> Option<f64> {
     None
 }
 
-fn format_fps(s: &mut String, fps: f64) {
-    s.clear();
-    // SAFETY: Writing to a String never fails
-    unsafe {
-        write!(s, "{:.0}", fps).unwrap_unchecked();
-    }
+fn format_fps(buffer: &mut String, fps: f64) {
+    *buffer = format!("{:.0}", fps);
 }
 
 /// Set up the UI camera, the text element and, attached to it, the plugin state.


### PR DESCRIPTION
This is my first ever PR, so I'm keeping it simple!

I spotted the `unsafe` keyword being used for something that looked fairly straightforward - it's a mutable String reference, so there shouldn't be any issues with changing its value. The reference just has to be de-referenced, which is perfectly safe as Rust guarantees there's only one mutable reference to a variable at a time.

Changes are tested & working.

I also have some ideas on other improvements so I may make a further PR that refactors the code a little, if that's okay?