### PR TITLE
Upgrade to Bevy 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ repository = "https://github.com/jomala/bevy_screen_diags/"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.6.0", default-features = false, features = ["render", "bevy_winit", "x11"] }
+bevy = { version = "0.7.0", default-features = false, features = ["render", "bevy_winit", "x11"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,7 @@ repository = "https://github.com/jomala/bevy_screen_diags/"
 edition = "2021"
 
 [dependencies]
+bevy = { version = "0.7.0", default-features = false, features = ["render"] }
+
+[dev-dependencies]
 bevy = { version = "0.7.0", default-features = false, features = ["render", "bevy_winit", "x11"] }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -3,7 +3,7 @@
 
 use bevy::prelude::*;
 
-use bevy_screen_diags::{ScreenDiagsPlugin, ScreenDiagsTimer};
+use bevy_screen_diags::{ScreenDiagsPlugin, ScreenDiagsState};
 
 fn main() {
     App::new()
@@ -23,14 +23,13 @@ fn setup(mut commands: Commands) {
 
 fn mouse_handler(
     mouse_button_input: Res<Input<MouseButton>>,
-    mut query: Query<&mut Timer, With<ScreenDiagsTimer>>,
+    mut diags_state: ResMut<ScreenDiagsState>,
 ) {
     if mouse_button_input.just_released(MouseButton::Left) {
-        let mut timer = query.single_mut();
-        if timer.paused() {
-            timer.unpause();
+        if diags_state.timer.paused() {
+            diags_state.timer.unpause();
         } else {
-            timer.pause();
+            diags_state.timer.pause();
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,10 @@ use bevy::{
     utils::Duration,
 };
 
+const FONT_SIZE: f32 = 32.0;
+const FONT_COLOR: Color = Color::RED;
+const UPDATE_INTERVAL: Duration = Duration::from_secs(1);
+
 /// A plugin that draws diagnostics on-screen with Bevy UI.
 ///
 /// Use our [marker struct](ScreenDiagsTimer) to manage the FPS counter.
@@ -41,7 +45,7 @@ pub struct ScreenDiagsState {
 impl Default for ScreenDiagsState {
     fn default() -> Self {
         Self {
-            timer: Timer::new(Duration::from_secs(1), true),
+            timer: Timer::new(UPDATE_INTERVAL, true),
             text_entity: None,
             fps_initialized: false,
         }
@@ -96,12 +100,9 @@ fn update(
 }
 
 fn extract_fps(diagnostics: Res<Diagnostics>) -> Option<f64> {
-    if let Some(fps) = diagnostics.get(FrameTimeDiagnosticsPlugin::FPS) {
-        if let Some(average) = fps.average() {
-            return Some(average);
-        }
-    }
-    None
+    diagnostics
+        .get(FrameTimeDiagnosticsPlugin::FPS)
+        .and_then(|fps| fps.average())
 }
 
 fn format_fps(s: &mut String, fps: f64) {
@@ -123,16 +124,16 @@ fn spawn_text(
                         value: "FPS: ".to_string(),
                         style: TextStyle {
                             font: handle.clone(),
-                            font_size: 32.0,
-                            color: Color::RED,
+                            font_size: FONT_SIZE,
+                            color: FONT_COLOR,
                         },
                     },
                     TextSection {
                         value: fps.unwrap_or_else(|| "...".to_string()),
                         style: TextStyle {
                             font: handle,
-                            font_size: 32.0,
-                            color: Color::RED,
+                            font_size: FONT_SIZE,
+                            color: FONT_COLOR,
                         },
                     },
                 ],


### PR DESCRIPTION
This forced breaking backwards compatibility since Timer is no longer a Component. The new approach goes back to using a resource, but ends up being even simpler.