### PR TITLE
bump bevy dependency to 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "bevy_screen_diags"
 description = "An on-screen FPS display for bevyengine.org"
 categories = ["game-development"]
 keywords = ["bevy", "gamedev", "graphics"]
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Jonathan Lawn <Jonathan.M.Lawn@gmail.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -12,4 +12,4 @@ repository = "https://github.com/jomala/bevy_screen_diags/"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.7.0", default-features = false, features = ["render", "bevy_winit", "x11"] }
+bevy = { version = "0.8.0", default-features = false, features = ["render", "bevy_winit", "x11", "bevy_asset"] }


### PR DESCRIPTION
bumps the bevy dependency to 0.8.0 and adds the required bevy_asset feature.