### PR TITLE
Add example showing how to customize FPS display

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,6 @@ the font at that path in this project (which is FiraSans-Bold).
 The `basic` example just shows the FPS count on a grey background, but you can click your mouse on
 the window to add or remove the display.
 
+The `customized` example uses the `ScreenDiagsText` marker component to tweak the font and position of the FPS display.
+
 Contributions to the crate are welcome.

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,4 @@
-//! This example illustrates how to enable and disable the FPS text in the bottom left hand corner
+//! This example illustrates how to enable and disable the FPS text in the top left hand corner
 //! for a blank screen.
 
 use bevy::prelude::*;

--- a/examples/customized.rs
+++ b/examples/customized.rs
@@ -1,0 +1,32 @@
+//! This example illustrates how to customize the font or position of the FPS display.
+
+use bevy::prelude::*;
+
+use bevy_screen_diags::{ScreenDiagsText, ScreenDiagsTextPlugin};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        // Include the plugin
+        .add_plugins(ScreenDiagsTextPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(PostStartup, (tweak_fps_font, tweak_fps_position))
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2dBundle::default());
+}
+
+fn tweak_fps_font(mut text_query: Query<&mut Text, With<ScreenDiagsText>>) {
+    let mut text = text_query.single_mut();
+    text.sections[0].style.color = Color::GREEN;
+    text.sections[0].style.font_size = 92.0;
+}
+
+fn tweak_fps_position(mut style_query: Query<&mut Style, With<ScreenDiagsText>>) {
+    let mut style = style_query.single_mut();
+    style.position_type = PositionType::Absolute;
+    style.right = Val::Percent(0.0);
+    style.bottom = Val::Percent(0.0);
+}


### PR DESCRIPTION
Adds a new example showing how to customize FPS display
 - Adds new `customized.rs` example
 - Fixes comment in `basic.rs` example
 - Updates README

I'm not 100% sure this is *the* proper way to customize the FPS display, but it works. I did use `single_mut()` which unwraps, but I guess it's OK for an example.